### PR TITLE
Add installation of libsecret-1-dev and libsodium-dev

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,6 +27,7 @@
     },
     "postCreateCommand": {
         "setup": [
+            "sudo apt-get update && sudo apt-get install -y libsecret-1-dev libsodium-dev",
             "R",
             "-q",
             "-e",


### PR DESCRIPTION
This pull request makes a small update to the development container setup by ensuring necessary system libraries are installed during initialization. This helps prevent build or runtime issues related to missing dependencies.

- Development environment setup:
  * [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R30): Adds installation of `libsecret-1-dev` and `libsodium-dev` packages in the `postCreateCommand` to ensure required libraries are available in the container.